### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub's certification program",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
## Description
This PR addresses Issue #6: "🚨 Missing Activity: GitHub Skills"

### Changes Made
- Added the GitHub Skills activity to the activities dictionary in app.py
- Set appropriate description mentioning the certification program
- Configured it for Wednesdays from 3:30 PM - 5:00 PM
- Set a capacity of 25 students
- Started with an empty participants list

### Issue Context
The principal recently announced a partnership with GitHub to teach practical coding and collaboration skills. This activity is time-sensitive as registrations close by the end of this week, and students need this for their college applications.

### Testing
Verified that the application runs correctly with the new activity available in the list.

Closes #6